### PR TITLE
Use `poetry` to handle dependency management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,51 @@ This is the source repository for the Zcash Developers Hub website: https://zcas
 
 For now, this repo hosts the script used to generate ECC's development dependency graph, and a workflow that generates and hosts it.
 
-## Generating DAGs
+## Setup
 
-The `zcash-issue-dag.py` script has two required environment variables:
+This project uses `poetry` for dependency management: https://python-poetry.org/
+
+The scripts provided by this project require two environment variables:
 
 - `GITHUB_TOKEN`: a GitHub API token with permission to read the necessary repositories.
 - `ZENHUB_TOKEN`: a ZenHub API token.
 
-It also supports several configuration options, also supplied as environment variables:
+The DAG script depends upon graphql APIs for github which can be generated
+using the following example script:
+
+```bash
+#!/usr/bin/env bash
+
+poetry run python3 -m sgqlc.introspection \
+  --exclude-deprecated \
+  --exclude-description \
+  -H "Authorization: bearer $GITHUB_TOKEN" \
+  https://api.github.com/graphql \
+  github_schema.json
+
+poetry run sgqlc-codegen schema github_schema.json github_schema.py
+```
+
+## Generating DAGs
+
+The `zcash-issue-dag.py` script also supports several configuration options,
+also supplied as environment variables:
 
 - `DAG_VIEW=[core|wallet|zf]`: The DAG to render (default: `core`).
 - `SHOW_MILESTONES=[true|false]`: Whether or not to render GitHub milestones as boxes (default: `false`).
 - `INCLUDE_FINISHED=[true|false]`: Whether or not to include closed issues with no open blockers (default: `false`).
 
-Here's an example script for easily running the DAG script:
+Here's an example script for easily running the DAG generator:
 
 ```bash
 #!/usr/bin/env bash
+
 DAG_VIEW=core \
 SHOW_MILESTONES=false \
 GITHUB_TOKEN=<INSERT> \
 ZENHUB_TOKEN=<INSERT> \
-python ./zcash-issue-dag.py
+
+poetry run python ./zcash-issue-dag.py
 ```
+
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ poetry run sgqlc-codegen schema github_schema.json github_schema.py
 
 ## Generating DAGs
 
-The `zcash-issue-dag.py` script also supports several configuration options,
+The `zcash-issue-dag.py` script supports several configuration options,
 also supplied as environment variables:
 
 - `DAG_VIEW=[core|wallet|zf]`: The DAG to render (default: `core`).
@@ -47,7 +47,6 @@ DAG_VIEW=core \
 SHOW_MILESTONES=false \
 GITHUB_TOKEN=<INSERT> \
 ZENHUB_TOKEN=<INSERT> \
-
 poetry run python ./zcash-issue-dag.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
-name = "zcash-core-devtools"
+name = "zcash-developer-tools"
 version = "0.1.0"
-description = "Zcash Core Developer Tools"
+description = "Zcash Developer Tools"
 authors = [
-    "Jack Grigg <jack@z.cash>",
+    "Jack Grigg <jack@electriccoin.co>",
 ]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -18,5 +18,5 @@ classifiers = [
 python = "^3.7"
 drest = "0.9.12"
 networkx = "2.6.3"
-sgqlc = "14.1"
 pygraphviz = "1.7"
+sgqlc = "14.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "zcash-core-devtools"
+version = "0.1.0"
+description = "Zcash Core Developer Tools"
+authors = [
+    "Jack Grigg <jack@z.cash>",
+]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/zcash/developers/"
+repository = "https://github.com/zcash/developers/"
+documentation = "https://github.com/zcash/developers/"
+classifiers = [
+    "Private :: Do Not Upload",
+]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+drest = "0.9.12"
+networkx = "2.6.3"
+sgqlc = "14.1"
+pygraphviz = "1.7"


### PR DESCRIPTION
This also updates the README.md file with instructions on how
to generate the graphql APIs for github that the DAG generator
depends upon.