### PR TITLE
Wallet Dag: Add MnemonicSwift repo, remove unused repos

### DIFF
--- a/zcash-issue-dag.py
+++ b/zcash-issue-dag.py
@@ -43,10 +43,9 @@ WALLET_REPOS = {
     151763639: ('zcash', 'zcash-android-wallet-sdk'),
     159714694: ('zcash', 'lightwalletd'),
     185480114: ('zcash', 'ZcashLightClientKit'),
-    223814143: ('zcash', 'zcash-android-wallet'),
-    225922879: ('zcash', 'zcash-ios-wallet'),
     387551125: ('zcash', 'secant-ios-wallet'),
     390808594: ('zcash', 'secant-android-wallet'),
+    270825987: ('zcash-hackworks', 'MnemonicSwift'),
     439137887: ('zcash-hackworks', 'zcash-light-client-ffi'),
 }
 


### PR DESCRIPTION
This commit removes the repos `zcash-ios-wallet` and `zcash-android-wallet`
since the are not being actively developed and are on maintenance only.
It also adds MnemonicSwift which is a library the wallet team develops
actively.