### PR TITLE
Create DAGs for Android and iOS Specific projects

### DIFF
--- a/zcash-issue-dag.py
+++ b/zcash-issue-dag.py
@@ -72,8 +72,8 @@ REPO_SETS = {
     'core': CORE_REPOS,
     'halo2': HALO2_REPOS,
     'wallet': WALLET_REPOS,
-    'ios': IOS_REPOS,
-    'android': ANDROID_REPOS,
+    'wallet-ios': IOS_REPOS,
+    'wallet-android': ANDROID_REPOS,
     'zf': ZF_REPOS,
 }
 

--- a/zcash-issue-dag.py
+++ b/zcash-issue-dag.py
@@ -49,6 +49,18 @@ WALLET_REPOS = {
     439137887: ('zcash-hackworks', 'zcash-light-client-ffi'),
 }
 
+ANDROID_REPOS = {
+    390808594: ('zcash', 'secant-android-wallet'),
+    151763639: ('zcash', 'zcash-android-wallet-sdk')
+}
+
+IOS_REPOS = {
+    387551125: ('zcash', 'secant-ios-wallet'),
+    185480114: ('zcash', 'ZcashLightClientKit'),
+    270825987: ('zcash-hackworks', 'MnemonicSwift'),
+    439137887: ('zcash-hackworks', 'zcash-light-client-ffi')
+}
+
 ZF_REPOS = {
     205255683: ('ZcashFoundation', 'zebra'),
     225479018: ('ZcashFoundation', 'redjubjub'),
@@ -60,6 +72,8 @@ REPO_SETS = {
     'core': CORE_REPOS,
     'halo2': HALO2_REPOS,
     'wallet': WALLET_REPOS,
+    'ios': IOS_REPOS,
+    'android': ANDROID_REPOS,
     'zf': ZF_REPOS,
 }
 


### PR DESCRIPTION
This commit maintains the Wallet DAG and creates two more
One for the repos that are used on for the iOS SDK and Wallet
and the other for the Android SDK and Wallet.