### PR TITLE
[#17] Create Android and iOS specific views of the Wallet DAG

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -66,6 +66,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
           DAG_VIEW: wallet
+          SHOW_MILESTONES: true
+
+      - name: Render ECC iOS Wallet DAG
+        run: python3 ./zcash-issue-dag.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
+          DAG_VIEW: wallet-ios
+          SHOW_MILESTONES: true
+
+      - name: Render ECC Android Wallet DAG
+        run: python3 ./zcash-issue-dag.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
+          DAG_VIEW: wallet-android
+          SHOW_MILESTONES: true
 
       - name: Render ZF DAG
         run: python3 ./zcash-issue-dag.py

--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ ZENHUB_TOKEN=<INSERT> \
 poetry run python ./zcash-issue-dag.py
 ```
 
+You can find a series of template script files inside the folder `template_scripts`.
+
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
         <p>Currently this is just hosting DAGs showing dependencies between issues and PRs, for several Zcash teams.</p>
         <p><a href="zcash-core-dag">ECC core team DAG</a></p>
         <p><a href="zcash-wallet-dag">ECC wallet team DAG</a></p>
+        <p><a href="zcash-wallet-android-dag">ECC wallet team Android DAG</a></p>
+        <p><a href="zcash-wallet-ios-dag">ECC wallet team iOS DAG</a></p>
         <p><a href="zcash-zf-dag">ZF DAG</a></p>
         <p><a href="zcash-halo2-dag">Halo2-focused DAG</a></p>
     </body>

--- a/template_scripts/generate_schemas.sh
+++ b/template_scripts/generate_schemas.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#GITHUB_TOKEN=<INSERT> \
+#ZENHUB_TOKEN=<INSERT> \
+poetry run python3 -m sgqlc.introspection \
+  --exclude-deprecated \
+  --exclude-description \
+  -H "Authorization: bearer $GITHUB_TOKEN" \
+  https://api.github.com/graphql \
+  github_schema.json
+
+poetry run sgqlc-codegen schema github_schema.json github_schema.py

--- a/template_scripts/generate_wallet_android_dag.sh
+++ b/template_scripts/generate_wallet_android_dag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+DAG_VIEW=wallet-android \
+SHOW_MILESTONES=true \
+#GITHUB_TOKEN=<INSERT> \
+#ZENHUB_TOKEN=<INSERT> \
+poetry run python ./zcash-issue-dag.py

--- a/template_scripts/generate_wallet_dag.sh
+++ b/template_scripts/generate_wallet_dag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+DAG_VIEW=wallet \
+SHOW_MILESTONES=true \
+#GITHUB_TOKEN=<INSERT> \
+#ZENHUB_TOKEN=<INSERT> \
+poetry run python ./zcash-issue-dag.py

--- a/template_scripts/generate_wallet_ios_dag.sh
+++ b/template_scripts/generate_wallet_ios_dag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+DAG_VIEW=wallet-ios \
+SHOW_MILESTONES=true \
+#GITHUB_TOKEN=<INSERT> \
+#ZENHUB_TOKEN=<INSERT> \
+poetry run python ./zcash-issue-dag.py


### PR DESCRIPTION
Closes #17

This adds two new views of the Wallet DAG: `ios` and `android`. They
focus only on the repos directly related to those platforms proving
a more concise DAG that is more suitable for platform focused tasks
such as backlog grooming or sprint planning.

This commit also adds respective gh-pages.yml tasks, template scripts
for users building the DAGs locally and a `README.md` update.

Add `href` tags for Android and iOS DAGs