### PR TITLE
Number clusters individually to avoid collisions

### DIFF
--- a/zcash-issue-dag.py
+++ b/zcash-issue-dag.py
@@ -324,20 +324,23 @@ def main():
 
     ag = nx.nx_agraph.to_agraph(dg)
 
+    clusters = 0
     if SHOW_MILESTONES:
         # Identify milestone nbunches
         milestones = {n.milestone: [] for n in dg}
         for m in milestones:
             milestones[m] = [n for n in dg if n.milestone == m]
         del milestones[None]
-        for (i, (milestone, nodes)) in enumerate(milestones.items()):
-            ag.add_subgraph(nodes, 'cluster_%d' % i, label=milestone, color='blue')
+        for (milestone, nodes) in milestones.items():
+            ag.add_subgraph(nodes, 'cluster_%d' % clusters, label=milestone, color='blue')
+            clusters += 1
 
     if SHOW_EPICS:
-        for (i, (epic, issues)) in enumerate(issues_by_epic.items()):
+        for (epic, issues) in issues_by_epic.items():
             issues = [n for n in dg if (n.repo_id, n.issue_number) in issues]
             if issues:
-                ag.add_subgraph(issues, 'cluster_%d' % i, label=epic.title, color='blue')
+                ag.add_subgraph(issues, 'cluster_%d' % clusters, label=epic.title, color='blue')
+                clusters += 1
 
     # Draw the result!
     ag.graph_attr['rankdir'] = 'LR'


### PR DESCRIPTION
This fixes a bug where enabling epics and milestones together will cause their subgraph boxes to be merged.