### PR TITLE
Switch to using the milestone DAG in automated builds.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
+          SHOW_MILESTONES: true
 
       - name: Render ECC wallet DAG
         run: python3 ./zcash-issue-dag.py


### PR DESCRIPTION
The zcashd core dag is a bit crowded and hard to interpret without the milestones view enabled.