### PR TITLE
[#62] add zcash/wallet repo to Zcash Deprecation DAG

### DIFF
--- a/zcash-issue-dag.py
+++ b/zcash-issue-dag.py
@@ -85,6 +85,7 @@ ZCASHD_DEPRECATION_REPOS = {
     26987049: ('zcash', 'zcash'),
     47279130: ('zcash', 'zips'),
     85334928: ('zcash', 'librustzcash'),
+    863610221: ('zcash', 'wallet'),
 }
 
 POOL_DEPRECATION_REPOS = {


### PR DESCRIPTION
Note: I don't have a Zenhub token to test this. 

closes #62

