### PR TITLE
Switch from poetry to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@ public/*.svg
 github_schema.json
 github_schema.py
 
-poetry.lock
-
 GITHUB_TOKEN
 ZENHUB_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ public/*.svg
 github_schema.json
 github_schema.py
 
+zcash_developer_tools.egg-info
+
 GITHUB_TOKEN
 ZENHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ For now, this repo hosts the script used to generate ECC's development dependenc
 
 ## Setup
 
-This project uses `poetry` for dependency management: https://python-poetry.org/
+This project uses `uv` for dependency management: https://docs.astral.sh/uv/
 It also depends on the Graphviz library; for Debian-based distros, install the
 `libgraphviz-dev` package.
 
-After installing `poetry`, run `poetry install`.
+After installing `uv`, run `uv sync`.
 
 ### Authorization Tokens
 
@@ -46,5 +46,5 @@ supplied as environment variables:
 Example command:
 
 ```
-DAG_VIEW=core SHOW_MILESTONES=false poetry run python ./zcash-issue-dag.py
+DAG_VIEW=core SHOW_MILESTONES=false uv run ./zcash-issue-dag.py
 ```

--- a/gen-dag.sh
+++ b/gen-dag.sh
@@ -11,5 +11,5 @@ do
     SHOW_EPICS=true \
     GITHUB_TOKEN="$(cat GITHUB_TOKEN)" \
     ZENHUB_TOKEN="$(cat ZENHUB_TOKEN)" \
-    poetry run python ./zcash-issue-dag.py
+    uv run ./zcash-issue-dag.py
 done

--- a/gen-schema.sh
+++ b/gen-schema.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-poetry run python3 -m sgqlc.introspection \
+uv run python3 -m sgqlc.introspection \
   --exclude-deprecated \
   --exclude-description \
   -H "Authorization: bearer $(cat GITHUB_TOKEN)" \
   https://api.github.com/graphql \
   github_schema.json
 
-poetry run sgqlc-codegen schema github_schema.json github_schema.py
+uv run sgqlc-codegen schema github_schema.json github_schema.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,28 @@
-[tool.poetry]
+[project]
 name = "zcash-developer-tools"
 version = "0.1.0"
-description = "Zcash Developer Tools"
+dependencies = [
+  "drest",
+  "networkx",
+  "pygraphviz",
+  "sgqlc",
+  "str2bool",
+]
+requires-python = ">= 3.8"
 authors = [
-    "Jack Grigg <jack@electriccoin.co>",
+  {name = "Jack Grigg", email = "jack@electriccoin.co"},
 ]
-license = "MIT OR Apache-2.0"
+description = "Zcash Developer Tools"
 readme = "README.md"
-homepage = "https://github.com/zcash/developers/"
-repository = "https://github.com/zcash/developers/"
-documentation = "https://github.com/zcash/developers/"
 classifiers = [
-    "Private :: Do Not Upload",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
+  "Private :: Do Not Upload",
 ]
-package-mode = false
 
-[tool.poetry.dependencies]
-python = "^3.8"
-drest = "0.9.12"
-networkx = "3.1"
-pygraphviz = "1.11"
-sgqlc = "16.3"
-str2bool = "1.1"
+[project.urls]
+Homepage = "https://github.com/zcash/developers"
+Documentation = "https://github.com/zcash/developers"
+Repository = "https://github.com/zcash/developers.git"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ drest
 networkx
 pygraphviz
 sgqlc
+str2bool

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,107 @@
+version = 1
+requires-python = ">=3.8"
+
+[[package]]
+name = "drest"
+version = "0.9.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/86c8e61ab7573c2762b39d5b07de3997fbe0dbf56b41b3047165612c1b11/drest-0.9.12.tar.gz", hash = "sha256:5d88a53d19b99844baabebc080452dd0d83030e812a8994719e9723d5356542e", size = 29734 }
+
+[[package]]
+name = "graphql-core"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/b5/ebc6fe3852e2d2fdaf682dddfc366934f3d2c9ef9b6d1b0e6ca348d936ba/graphql_core-3.2.5.tar.gz", hash = "sha256:e671b90ed653c808715645e3998b7ab67d382d55467b7e2978549111bbabf8d5", size = 504664 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/dc/078bd6b304de790618ebb95e2aedaadb78f4527ac43a9ad8815f006636b6/graphql_core-3.2.5-py3-none-any.whl", hash = "sha256:2f150d5096448aa4f8ab26268567bbfeef823769893b39c1a2e1409590939c8a", size = 203189 },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854 },
+]
+
+[[package]]
+name = "networkx"
+version = "3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/a1/47b974da1a73f063c158a1f4cc33ed0abf7c04f98a19050e80c533c31f0c/networkx-3.1.tar.gz", hash = "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61", size = 2021691 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/05/9d4f9b78ead6b2661d6e8ea772e111fc4a9fbd866ad0c81906c11206b55e/networkx-3.1-py3-none-any.whl", hash = "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36", size = 2072251 },
+]
+
+[[package]]
+name = "pygraphviz"
+version = "1.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/db/cc09516573e79a35ac73f437bdcf27893939923d1d06b439897ffc7f3217/pygraphviz-1.11.zip", hash = "sha256:a97eb5ced266f45053ebb1f2c6c6d29091690503e3a5c14be7f908b37b06f2d4", size = 120803 }
+
+[[package]]
+name = "pyparsing"
+version = "3.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/08/13f3bce01b2061f2bbd582c9df82723de943784cf719a35ac886c652043a/pyparsing-3.1.4.tar.gz", hash = "sha256:f86ec8d1a83f11977c9a6ea7598e8c27fc5cddfa5b07ea2241edbbde1d7bc032", size = 900231 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/0c/0e3c05b1c87bb6a1c76d281b0f35e78d2d80ac91b5f8f524cebf77f51049/pyparsing-3.1.4-py3-none-any.whl", hash = "sha256:a6a7ee4235a3f944aa1fa2249307708f893fe5717dc603503c6c7969c070fb7c", size = 104100 },
+]
+
+[[package]]
+name = "sgqlc"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphql-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/ab/a37f739b4cadd77ac9603cb473db545462062784cbbb2f2d2c45309eb986/sgqlc-16.4.tar.gz", hash = "sha256:a1a32db1c573edae229dbb61f6ae0a546aecceaaed2bac0652992a73e8c95017", size = 242759 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/b7/82120310147682c2980f245d8d691cc5f3b87772013ff09bd0a917ce0df9/sgqlc-16.4-py3-none-any.whl", hash = "sha256:91f9e7e624c76613288b917f583c6b19c8d908a213199f1cb6e918e8f3901246", size = 82204 },
+]
+
+[[package]]
+name = "str2bool"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/8c/42e61df3b86bb675b719877283da915d3db93fb0d1820fc7bf2a9153f739/str2bool-1.1.zip", hash = "sha256:dbc3c917dca831904bce8568f6fb1f91435fcffc2ec4a46d62c9aa08d7cf77c3", size = 1567 }
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "zcash-developer-tools"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "drest" },
+    { name = "networkx" },
+    { name = "pygraphviz" },
+    { name = "sgqlc" },
+    { name = "str2bool" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drest" },
+    { name = "networkx" },
+    { name = "pygraphviz" },
+    { name = "sgqlc" },
+    { name = "str2bool" },
+]


### PR DESCRIPTION
poetry does not have support for passing settings to the PEP 517 build backend, which means on some platforms like macOS, pygraphviz cannot be built. uv does support this.