### PR TITLE
Remove the remaining ZenHub references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,6 @@ public/*.svg
 github_schema.json
 github_schema.py
 
-zenhub_schema.json
-zenhub_schema.py
-
 GITHUB_TOKEN
-ZENHUB_TOKEN
 
 zcash_developer_tools.egg-info

--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ It also depends on the Graphviz library; for Debian-based distros, install the
 
 After installing `uv`, run `uv sync`.
 
-### Authorization Tokens
+### Authorization Token
 
-The scripts provided by this project require two files:
+The scripts provided by this project require one file:
 
 - `GITHUB_TOKEN`: a GitHub API token with permission to read the necessary repositories.
-- `ZENHUB_TOKEN`: a ZenHub REST API token. (Not a GraphQL token.)
 
-After generating each token, paste the literal contents into the associated file. There is a
-`.gitignore` which ignores these files to ensure they are not committed. Be careful to avoid
-that editor temporary files or any copies or renames of these files aren't committed.
+After generating the token, paste the literal contents into the associated file. There is a
+`.gitignore` which ignores this file to ensure it is not committed. Be careful to avoid
+that editor temporary files or any copies or renames of this file aren't committed.
 
 You can generate a GitHub token with [this url](https://github.com/settings/tokens/new). This
 token should not have any excess authority; it only needs public read access! Make sure all of
@@ -40,7 +39,6 @@ supplied as environment variables:
 
 - `DAG_VIEW=[core|halo2|tfl|wallet|wallet-ios|wallet-android|zf]`: The DAG to render (default: `core`).
 - `SHOW_MILESTONES=[true|false]`: Whether or not to render GitHub milestones as boxes (default: `false`).
-- `SHOW_EPICS=[true|false]`: Whether or not to render ZenHub epics as boxes (default: `false`).
 - `INCLUDE_FINISHED=[true|false]`: Whether or not to include closed issues with no open blockers (default: `false`).
 
 Example command:

--- a/gen-dag.sh
+++ b/gen-dag.sh
@@ -8,8 +8,6 @@ do
     echo Generating ${view} DAG...
     DAG_VIEW=${view} \
     SHOW_MILESTONES=true \
-    SHOW_EPICS=true \
     GITHUB_TOKEN="$(cat GITHUB_TOKEN)" \
-    ZENHUB_TOKEN="$(cat ZENHUB_TOKEN)" \
     uv run ./zcash-issue-dag.py
 done

--- a/gen-schema.sh
+++ b/gen-schema.sh
@@ -9,11 +9,3 @@ uv run python3 -m sgqlc.introspection \
   github_schema.json
 
 uv run sgqlc-codegen schema github_schema.json github_schema.py
-
-uv run python3 -m sgqlc.introspection \
-  --exclude-description \
-  -H "Authorization: Bearer $(cat ZENHUB_TOKEN)" \
-  https://api.zenhub.com/public/graphql \
-  zenhub_schema.json
-
-uv run sgqlc-codegen schema zenhub_schema.json zenhub_schema.py

--- a/helpers/github.py
+++ b/helpers/github.py
@@ -126,7 +126,7 @@ def download_issues(endpoint, nodes, REPOS):
 
     ret = {}
 
-    # Ensure that any graph nodes from ZenHub that are not in the repos we care about have
+    # Ensure that any graph nodes that are not in the repos we care about have
     # default entries, to simplify subsequent graph manipulation code.
     for repo, issue in [(repo, issue) for (repo, issue) in nodes if repo not in REPOS]:
         ret[(repo, issue)] = GitHubIssue(repo, issue, None, REPOS)


### PR DESCRIPTION
#87 took ZenHub out of the Python, but a few references survived in the shell scripts, the README and `.gitignore`. This clears out what was left.

What was still there:

- **`gen-schema.sh`** still introspected the ZenHub GraphQL API and ran `sgqlc-codegen` to produce `zenhub_schema.py`. Nothing imports that module any more, so it was generating a file no code reads — and it needs a `ZENHUB_TOKEN` file to get that far.
- **`gen-dag.sh`** still passed `SHOW_EPICS=true` and `ZENHUB_TOKEN` to `zcash-issue-dag.py`. Neither is read any more — the script only looks at `GITHUB_TOKEN`, `DAG_VIEW`, `TERMINATE_AT`, `ONLY_INCLUDE`, `INCLUDE_FINISHED`, `PRUNE_FINISHED` and `SHOW_MILESTONES`. Without a `ZENHUB_TOKEN` file sitting in the working directory it also prints `cat: ZENHUB_TOKEN: No such file or directory` once per view. It's harmless — the assignment doesn't trip `set -e`, so the loop still finishes — but it's a confusing thing to hit when you're setting the repo up for the first time.
- **`README.md`** asked for two token files and documented `SHOW_EPICS`, so a new contributor would go off and create a ZenHub token they don't actually need.
- **`.gitignore`** still ignored `zenhub_schema.json`, `zenhub_schema.py` and `ZENHUB_TOKEN`.
- One stale comment in **`helpers/github.py`** about "graph nodes from ZenHub" — those come from GitHub now.

I checked that nothing reads `SHOW_EPICS` or `ZENHUB_TOKEN` before pulling them out, and `grep -ri zenhub` now comes back empty across the tree. `bash -n` passes on both scripts.

One thing I noticed but deliberately left out of this PR, happy to send it separately if it'd be useful: the README lists seven `DAG_VIEW` values, but `REPO_SETS` in `helpers/github.py` currently has fourteen — `zallet`, `ecc`, `zf-frost`, `zf-devops`, `zcashd-deprecation`, `sprout-deprecation` and `transparent-deprecation` don't get a mention. `TERMINATE_AT`, `ONLY_INCLUDE` and `PRUNE_FINISHED` aren't documented either. Felt like a separate change from the ZenHub cleanup.
